### PR TITLE
add auth interceptor

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,6 +45,8 @@ subprojects {
         implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")
         testImplementation("org.springframework.boot:spring-boot-starter-test")
         testImplementation("io.projectreactor:reactor-test")
+        implementation("org.springframework.boot:spring-boot-starter-web")
+
 
 //        // springdoc-openapi
 //        implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,7 +47,6 @@ subprojects {
         testImplementation("io.projectreactor:reactor-test")
         implementation("org.springframework.boot:spring-boot-starter-web")
 
-
 //        // springdoc-openapi
 //        implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2")
 

--- a/sulsul-api/build.gradle.kts
+++ b/sulsul-api/build.gradle.kts
@@ -1,7 +1,6 @@
 dependencies {
     implementation(project(":sulsul-domain"))
 
-    implementation("org.springframework.boot:spring-boot-starter-web")
     // implementation("org.springframework.boot:spring-boot-starter-security")
 
     // swagger

--- a/sulsul-api/src/main/kotlin/will/of/d/sulsul/config/WebMvcConfig.kt
+++ b/sulsul-api/src/main/kotlin/will/of/d/sulsul/config/WebMvcConfig.kt
@@ -2,14 +2,12 @@ package will.of.d.sulsul.config
 
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry
-
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 import will.of.d.sulsul.interceptor.AuthenticationInterceptor
 
-
 @Configuration
 class WebMvcConfig(
-    private val authenticationInterceptor: AuthenticationInterceptor,
+    private val authenticationInterceptor: AuthenticationInterceptor
 ) : WebMvcConfigurer {
     override fun addInterceptors(registry: InterceptorRegistry) {
         registry.addInterceptor(authenticationInterceptor)

--- a/sulsul-api/src/main/kotlin/will/of/d/sulsul/config/WebMvcConfig.kt
+++ b/sulsul-api/src/main/kotlin/will/of/d/sulsul/config/WebMvcConfig.kt
@@ -1,0 +1,18 @@
+package will.of.d.sulsul.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry
+
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+import will.of.d.sulsul.interceptor.AuthenticationInterceptor
+
+
+@Configuration
+class WebMvcConfig(
+    private val authenticationInterceptor: AuthenticationInterceptor,
+) : WebMvcConfigurer {
+    override fun addInterceptors(registry: InterceptorRegistry) {
+        registry.addInterceptor(authenticationInterceptor)
+            .excludePathPatterns("/health")
+    }
+}

--- a/sulsul-api/src/main/kotlin/will/of/d/sulsul/interceptor/AuthenticationInterceptor.kt
+++ b/sulsul-api/src/main/kotlin/will/of/d/sulsul/interceptor/AuthenticationInterceptor.kt
@@ -1,0 +1,44 @@
+package will.of.d.sulsul.interceptor
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Component
+import org.springframework.web.servlet.HandlerInterceptor
+import will.of.d.sulsul.auth.KakaoAuthService
+import will.of.d.sulsul.log.Logger
+import will.of.d.sulsul.user.UserService
+
+@Component
+class AuthenticationInterceptor(
+    private val kakaoAuthService: KakaoAuthService,
+    private val userService: UserService,
+) : HandlerInterceptor {
+    
+    override fun preHandle(request: HttpServletRequest, response: HttpServletResponse, handler: Any): Boolean {
+        val accessToken = request.getAccessToken()
+        if (accessToken == null) {
+            response.sendError(HttpStatus.UNAUTHORIZED.value(), "no token")
+            return false
+        }
+
+        return try {
+            val tokenInfo = kakaoAuthService.getTokenInfo(accessToken)
+            userService.getUser(tokenInfo.id) ?: userService.signup(tokenInfo.id)
+            true
+        } catch (e : Exception) {
+            response.sendError(HttpStatus.UNAUTHORIZED.value(), e.message)
+            false
+        }
+    }
+
+    private fun HttpServletRequest.getAccessToken() : String? {
+        return this.getHeader("Authorization")?.let { token ->
+                if (token.startsWith("Bearer ")) {
+                    token.replaceFirst("Bearer ", "")
+                } else {
+                    null
+                }
+            }
+    }
+}

--- a/sulsul-api/src/main/kotlin/will/of/d/sulsul/interceptor/AuthenticationInterceptor.kt
+++ b/sulsul-api/src/main/kotlin/will/of/d/sulsul/interceptor/AuthenticationInterceptor.kt
@@ -6,15 +6,14 @@ import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
 import org.springframework.web.servlet.HandlerInterceptor
 import will.of.d.sulsul.auth.KakaoAuthService
-import will.of.d.sulsul.log.Logger
 import will.of.d.sulsul.user.UserService
 
 @Component
 class AuthenticationInterceptor(
     private val kakaoAuthService: KakaoAuthService,
-    private val userService: UserService,
+    private val userService: UserService
 ) : HandlerInterceptor {
-    
+
     override fun preHandle(request: HttpServletRequest, response: HttpServletResponse, handler: Any): Boolean {
         val accessToken = request.getAccessToken()
         if (accessToken == null) {
@@ -26,19 +25,19 @@ class AuthenticationInterceptor(
             val tokenInfo = kakaoAuthService.getTokenInfo(accessToken)
             userService.getUser(tokenInfo.id) ?: userService.signup(tokenInfo.id)
             true
-        } catch (e : Exception) {
+        } catch (e: Exception) {
             response.sendError(HttpStatus.UNAUTHORIZED.value(), e.message)
             false
         }
     }
 
-    private fun HttpServletRequest.getAccessToken() : String? {
+    private fun HttpServletRequest.getAccessToken(): String? {
         return this.getHeader("Authorization")?.let { token ->
-                if (token.startsWith("Bearer ")) {
-                    token.replaceFirst("Bearer ", "")
-                } else {
-                    null
-                }
+            if (token.startsWith("Bearer ")) {
+                token.replaceFirst("Bearer ", "")
+            } else {
+                null
             }
+        }
     }
 }

--- a/sulsul-domain/build.gradle.kts
+++ b/sulsul-domain/build.gradle.kts
@@ -1,6 +1,7 @@
 dependencies {
     api("org.springframework.boot:spring-boot-starter-data-mongodb")
     implementation("com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.5")
+    implementation("org.springframework.boot:spring-boot-starter-webflux")
 
     // RDS 필요하면 사용
     // implementation("org.springframework.boot:spring-boot-starter-data-jpa")

--- a/sulsul-domain/src/main/kotlin/will/of/d/sulsul/auth/KakaoAuthService.kt
+++ b/sulsul-domain/src/main/kotlin/will/of/d/sulsul/auth/KakaoAuthService.kt
@@ -1,0 +1,42 @@
+package will.of.d.sulsul.auth
+
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.http.HttpStatusCode
+import org.springframework.stereotype.Service
+import org.springframework.web.reactive.function.client.WebClient
+import reactor.core.publisher.Mono
+import will.of.d.sulsul.exception.Unauthorized
+import will.of.d.sulsul.log.Logger
+
+@Service
+class KakaoAuthService(
+    @Qualifier("kakaoAuthWebClient")
+    private val kakaoAuthWebClient: WebClient,
+) {
+
+    companion object : Logger
+
+    fun getTokenInfo(accessToken: String): AccessTokenInfo {
+        return kakaoAuthWebClient.get().uri("/v1/user/access_token_info")
+            .header("Authorization", accessToken)
+            .retrieve()
+            .onStatus({ status -> (status.is5xxServerError || status.is4xxClientError) }) { response ->
+                val statusCode = response.statusCode()
+
+                val exeption = if (statusCode == HttpStatusCode.valueOf(401)) {
+                    Unauthorized("refresh token")
+                } else {
+                    Unauthorized("bad token")
+                }
+
+                log.debug("failed to decode token {}", response)
+                Mono.error(exeption)
+            }
+            .bodyToMono(AccessTokenInfo::class.java)
+            .block()!!
+    }
+}
+
+data class AccessTokenInfo(
+    val id : Long,
+)

--- a/sulsul-domain/src/main/kotlin/will/of/d/sulsul/auth/KakaoAuthService.kt
+++ b/sulsul-domain/src/main/kotlin/will/of/d/sulsul/auth/KakaoAuthService.kt
@@ -11,7 +11,7 @@ import will.of.d.sulsul.log.Logger
 @Service
 class KakaoAuthService(
     @Qualifier("kakaoAuthWebClient")
-    private val kakaoAuthWebClient: WebClient,
+    private val kakaoAuthWebClient: WebClient
 ) {
 
     companion object : Logger
@@ -38,5 +38,5 @@ class KakaoAuthService(
 }
 
 data class AccessTokenInfo(
-    val id : Long,
+    val id: Long
 )

--- a/sulsul-domain/src/main/kotlin/will/of/d/sulsul/configuration/WebClientConfig.kt
+++ b/sulsul-domain/src/main/kotlin/will/of/d/sulsul/configuration/WebClientConfig.kt
@@ -7,7 +7,7 @@ import org.springframework.web.reactive.function.client.WebClient
 @Configuration
 class WebClientConfig {
     @Bean
-    fun kakaoAuthWebClient() : WebClient {
+    fun kakaoAuthWebClient(): WebClient {
         return WebClient.builder()
             .baseUrl("https://kapi.kakao.com")
             .build()

--- a/sulsul-domain/src/main/kotlin/will/of/d/sulsul/configuration/WebClientConfig.kt
+++ b/sulsul-domain/src/main/kotlin/will/of/d/sulsul/configuration/WebClientConfig.kt
@@ -1,0 +1,15 @@
+package will.of.d.sulsul.configuration
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.reactive.function.client.WebClient
+
+@Configuration
+class WebClientConfig {
+    @Bean
+    fun kakaoAuthWebClient() : WebClient {
+        return WebClient.builder()
+            .baseUrl("https://kapi.kakao.com")
+            .build()
+    }
+}

--- a/sulsul-domain/src/main/kotlin/will/of/d/sulsul/exception/Unauthorized.kt
+++ b/sulsul-domain/src/main/kotlin/will/of/d/sulsul/exception/Unauthorized.kt
@@ -1,0 +1,3 @@
+package will.of.d.sulsul.exception
+
+class Unauthorized(msg : String) : RuntimeException(msg)

--- a/sulsul-domain/src/main/kotlin/will/of/d/sulsul/exception/Unauthorized.kt
+++ b/sulsul-domain/src/main/kotlin/will/of/d/sulsul/exception/Unauthorized.kt
@@ -1,3 +1,3 @@
 package will.of.d.sulsul.exception
 
-class Unauthorized(msg : String) : RuntimeException(msg)
+class Unauthorized(msg: String) : RuntimeException(msg)

--- a/sulsul-domain/src/main/kotlin/will/of/d/sulsul/user/User.kt
+++ b/sulsul-domain/src/main/kotlin/will/of/d/sulsul/user/User.kt
@@ -1,11 +1,11 @@
 package will.of.d.sulsul.user
 
 data class User(
-  val kakaoUserId: Long,
-)  {
+    val kakaoUserId: Long
+) {
     companion object {
-        fun from(entity: UserEntity) : User = User(
-            kakaoUserId = entity.kakaoUserId,
+        fun from(entity: UserEntity): User = User(
+            kakaoUserId = entity.kakaoUserId
         )
     }
 }

--- a/sulsul-domain/src/main/kotlin/will/of/d/sulsul/user/User.kt
+++ b/sulsul-domain/src/main/kotlin/will/of/d/sulsul/user/User.kt
@@ -1,0 +1,11 @@
+package will.of.d.sulsul.user
+
+data class User(
+  val kakaoUserId: Long,
+)  {
+    companion object {
+        fun from(entity: UserEntity) : User = User(
+            kakaoUserId = entity.kakaoUserId,
+        )
+    }
+}

--- a/sulsul-domain/src/main/kotlin/will/of/d/sulsul/user/UserEntity.kt
+++ b/sulsul-domain/src/main/kotlin/will/of/d/sulsul/user/UserEntity.kt
@@ -8,5 +8,5 @@ import org.springframework.data.mongodb.core.mapping.Document
 data class UserEntity(
     @Id
     val id: ObjectId? = null,
-    val kakaoUserId: Long,
+    val kakaoUserId: Long
 )

--- a/sulsul-domain/src/main/kotlin/will/of/d/sulsul/user/UserEntity.kt
+++ b/sulsul-domain/src/main/kotlin/will/of/d/sulsul/user/UserEntity.kt
@@ -1,0 +1,12 @@
+package will.of.d.sulsul.user
+
+import org.bson.types.ObjectId
+import org.springframework.data.annotation.Id
+import org.springframework.data.mongodb.core.mapping.Document
+
+@Document("user")
+data class UserEntity(
+    @Id
+    val id: ObjectId? = null,
+    val kakaoUserId: Long,
+)

--- a/sulsul-domain/src/main/kotlin/will/of/d/sulsul/user/UserRepository.kt
+++ b/sulsul-domain/src/main/kotlin/will/of/d/sulsul/user/UserRepository.kt
@@ -4,5 +4,5 @@ import org.bson.types.ObjectId
 import org.springframework.data.mongodb.repository.MongoRepository
 
 interface UserRepository : MongoRepository<UserEntity, ObjectId> {
-    fun findByKakaoUserId(kakaoUserId: Long) : UserEntity?
+    fun findByKakaoUserId(kakaoUserId: Long): UserEntity?
 }

--- a/sulsul-domain/src/main/kotlin/will/of/d/sulsul/user/UserRepository.kt
+++ b/sulsul-domain/src/main/kotlin/will/of/d/sulsul/user/UserRepository.kt
@@ -1,0 +1,8 @@
+package will.of.d.sulsul.user
+
+import org.bson.types.ObjectId
+import org.springframework.data.mongodb.repository.MongoRepository
+
+interface UserRepository : MongoRepository<UserEntity, ObjectId> {
+    fun findByKakaoUserId(kakaoUserId: Long) : UserEntity?
+}

--- a/sulsul-domain/src/main/kotlin/will/of/d/sulsul/user/UserService.kt
+++ b/sulsul-domain/src/main/kotlin/will/of/d/sulsul/user/UserService.kt
@@ -5,7 +5,7 @@ import will.of.d.sulsul.log.Logger
 
 @Service
 class UserService(
-    private val userRepository: UserRepository,
+    private val userRepository: UserRepository
 ) {
 
     companion object : Logger

--- a/sulsul-domain/src/main/kotlin/will/of/d/sulsul/user/UserService.kt
+++ b/sulsul-domain/src/main/kotlin/will/of/d/sulsul/user/UserService.kt
@@ -1,0 +1,26 @@
+package will.of.d.sulsul.user
+
+import org.springframework.stereotype.Service
+import will.of.d.sulsul.log.Logger
+
+@Service
+class UserService(
+    private val userRepository: UserRepository,
+) {
+
+    companion object : Logger
+
+    fun getUser(kakaoUserId: Long): User? {
+        return userRepository.findByKakaoUserId(kakaoUserId)?.let { User.from(it) }
+    }
+
+    fun signup(kakaoUserId: Long): User {
+        // TODO: 회원가입 시 Discord bot 알림
+        return userRepository.save(UserEntity(kakaoUserId = kakaoUserId))
+            .let {
+                User.from(it)
+            }.also {
+                log.info("signup $kakaoUserId")
+            }
+    }
+}


### PR DESCRIPTION
* /health 외의 엔드포인트에서 토큰을 검증합니다.
* 헤더에 토큰이 있다면 토큰을 검증합니다.
  * 토큰 검증은 카카오 서버에 요청합니다.
* 토큰이 만료되면 클라이언트에 토큰 갱신을 요청한다.
https://github.com/mashup-kr/sulsul-backend/issues/5