### PR TITLE
chore: allow ci on forked repository

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,8 +1,7 @@
 name: CI
 on:
-  pull_request:
-    branches:
-      - main
+  pull_request_target:
+    types: [opened, reopened, synchronize, edited]
 
 jobs:
   build:
@@ -10,6 +9,8 @@ jobs:
     steps:
       - name: 소스 코드 다운로드
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: JDK 다운로드
         uses: actions/setup-java@v3


### PR DESCRIPTION
forked repository에서도 github action이 trigger 되도록 수정합니다.