### PR TITLE
chore: add authorization schema on swagger

### DIFF
--- a/sulsul-api/src/main/kotlin/will/of/d/sulsul/config/SwaggerConfig.kt
+++ b/sulsul-api/src/main/kotlin/will/of/d/sulsul/config/SwaggerConfig.kt
@@ -2,6 +2,10 @@ package will.of.d.sulsul.config
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition
 import io.swagger.v3.oas.annotations.info.Info
+import io.swagger.v3.oas.models.Components
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.security.SecurityRequirement
+import io.swagger.v3.oas.models.security.SecurityScheme
 import org.springdoc.core.models.GroupedOpenApi
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -16,6 +20,28 @@ import will.of.d.sulsul.constant.ROOT_PACKAGE
     )
 )
 class SwaggerConfig {
+
+    @Bean
+    fun openApi(): OpenAPI {
+        val schemeName = "Authorization"
+        val securityRequirement = SecurityRequirement()
+            .addList(schemeName)
+        val components = Components()
+            .addSecuritySchemes(
+                schemeName,
+                SecurityScheme()
+                    .name(schemeName)
+                    .type(SecurityScheme.Type.HTTP)
+                    .`in`(SecurityScheme.In.HEADER)
+                    .scheme("bearer")
+                    .bearerFormat("JWT")
+            )
+
+        return OpenAPI()
+            .addSecurityItem(securityRequirement)
+            .components(components)
+    }
+
     @Bean
     fun groupedOpenApi(): GroupedOpenApi {
         return GroupedOpenApi.builder()

--- a/sulsul-api/src/main/kotlin/will/of/d/sulsul/config/WebMvcConfig.kt
+++ b/sulsul-api/src/main/kotlin/will/of/d/sulsul/config/WebMvcConfig.kt
@@ -14,7 +14,7 @@ class WebMvcConfig(
 ) : WebMvcConfigurer {
     override fun addInterceptors(registry: InterceptorRegistry) {
         registry.addInterceptor(authenticationInterceptor)
-            .excludePathPatterns("/health")
+            .excludePathPatterns("/health", "/swagger-ui/**", "/v3/api-docs/**")
     }
 
     override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver>) {


### PR DESCRIPTION
![image](https://github.com/mash-up-kr/sulsul-backend/assets/34934883/d8df6497-e2c2-4529-921b-3cd86413466c)

스웨거에서 토큰을 입력할 수 있도록 설정을 추가합니다.