### PR TITLE
Swagger 이슈 해결

### DIFF
--- a/sulsul-api/src/main/kotlin/will/of/d/sulsul/config/SwaggerConfig.kt
+++ b/sulsul-api/src/main/kotlin/will/of/d/sulsul/config/SwaggerConfig.kt
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.models.Components
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.security.SecurityRequirement
 import io.swagger.v3.oas.models.security.SecurityScheme
+import io.swagger.v3.oas.models.servers.Server
 import org.springdoc.core.models.GroupedOpenApi
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -39,6 +40,7 @@ class SwaggerConfig {
             )
 
         return OpenAPI()
+            .addServersItem(Server().url("/"))
             .addSecurityItem(securityRequirement)
             .components(components)
     }


### PR DESCRIPTION
Swagger에서 HTTP 요청을 할 때, 배포 서버의 schema는 `https`이지만 `request url`이 `http` 로 보이는 문제 해결