### PR TITLE
fix: api response schema

### DIFF
--- a/sulsul-api/src/main/kotlin/will/of/d/sulsul/alcohol/drinkingLimit/dto/response/DrinkRes.kt
+++ b/sulsul-api/src/main/kotlin/will/of/d/sulsul/alcohol/drinkingLimit/dto/response/DrinkRes.kt
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "주종, 주량을 나타내는 객체")
 data class DrinkRes(
-    @Schema(description = "주량등록 시 설정한 주종 이름")
+    @Schema(description = "주량등록 시 설정한 주종 이름", allowableValues = ["소주", "와인", "맥주", "위스키", "고량주"])
     val drinkType: String,
 
     @Schema(description = "주량등록 시 설정한 잔 수")


### PR DESCRIPTION
프론트엔드의 요청으로 `drinkType`에 들어오는 값 리스트 Swagger에서 조회할 수 있도록 수정