### PR TITLE
환경별로 swagger에서의 base url 설정

### DIFF
--- a/sulsul-api/src/main/kotlin/will/of/d/sulsul/config/SwaggerConfig.kt
+++ b/sulsul-api/src/main/kotlin/will/of/d/sulsul/config/SwaggerConfig.kt
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.models.security.SecurityRequirement
 import io.swagger.v3.oas.models.security.SecurityScheme
 import io.swagger.v3.oas.models.servers.Server
 import org.springdoc.core.models.GroupedOpenApi
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import will.of.d.sulsul.constant.MOCK_API
@@ -21,7 +22,10 @@ import will.of.d.sulsul.constant.ROOT_PACKAGE
         version = "v0"
     )
 )
-class SwaggerConfig {
+class SwaggerConfig(
+    @Value("\${swagger.host.url}")
+    val serverHostUrl: String
+) {
 
     @Bean
     fun openApi(): OpenAPI {
@@ -40,7 +44,7 @@ class SwaggerConfig {
             )
 
         return OpenAPI()
-            .addServersItem(Server().url("/"))
+            .addServersItem(Server().url(serverHostUrl))
             .addSecurityItem(securityRequirement)
             .components(components)
     }

--- a/sulsul-api/src/main/resources/application-local.yml
+++ b/sulsul-api/src/main/resources/application-local.yml
@@ -1,0 +1,3 @@
+swagger:
+  host:
+    url: "http://localhost:8080"

--- a/sulsul-api/src/main/resources/application-prod.yml
+++ b/sulsul-api/src/main/resources/application-prod.yml
@@ -1,0 +1,3 @@
+swagger:
+  host:
+    url: "https://sulsul.app"


### PR DESCRIPTION
## 작업내용
- `application-local.yml`, `application-prod.yml` 생성
- `swagger.host.url` 을 실행(배포)되는 환경에 따라 다르게 적용하도록 `@Value` 이용

클라이언트는 `/v3/api-docs/sulsul-api` 로부터 받은 response로 openapi-generator로 openapi spec에 맞춰진 swagger로 개발을 하기 때문에, base url을 지정해주게 되면 프론트엔드에서는 swagger가 변경되어도 수정할 필요없이 openapi-generator로 수정사항을 업데이트받으면 됨