### PR TITLE
주량 측정 결과 리스트 조회 (술약속 카드 리스트 조회)

### DIFF
--- a/sulsul-api/src/main/kotlin/will/of/d/sulsul/alcohol/drinkingMeasurement/controller/DrinkingMeasurementController.kt
+++ b/sulsul-api/src/main/kotlin/will/of/d/sulsul/alcohol/drinkingMeasurement/controller/DrinkingMeasurementController.kt
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import will.of.d.sulsul.alcohol.drinkingMeasurement.dto.request.DrinkingMeasurementReq
+import will.of.d.sulsul.alcohol.drinkingMeasurement.dto.response.DrinkingMeasurementListRes
 import will.of.d.sulsul.alcohol.drinkingMeasurement.dto.response.DrinkingMeasurementRes
 import will.of.d.sulsul.alcohol.drinkingMeasurement.service.DrinkingMeasurementApplicationService
 import will.of.d.sulsul.user.User
@@ -43,7 +44,7 @@ class DrinkingMeasurementController(
     @Operation(summary = "주량 측정 결과 조회 API")
     @ApiResponses(
         value = [
-            ApiResponse(responseCode = "200", description = "주량 등록 성공", content = [Content(schema = Schema(implementation = DrinkingMeasurementRes::class))]),
+            ApiResponse(responseCode = "200", description = "주량 측정 결과 조회 성공", content = [Content(schema = Schema(implementation = DrinkingMeasurementRes::class))]),
             ApiResponse(responseCode = "404", description = "레포트가 존재하지 않음", content = [Content(schema = Schema(implementation = String::class))]),
             ApiResponse(responseCode = "401", description = "토큰 정보 없거나 만료됨", content = [Content(schema = Schema(implementation = String::class))]),
             ApiResponse(responseCode = "500", description = "서버 에러", content = [Content(schema = Schema(implementation = String::class))])
@@ -52,6 +53,21 @@ class DrinkingMeasurementController(
     @GetMapping("/{reportId}")
     fun getReport(@PathVariable reportId: String): ResponseEntity<DrinkingMeasurementRes> {
         val res = drinkingMeasurementApplicationService.getMeasurementReport(reportId)
+        return ResponseEntity.ok(res)
+    }
+
+    @Operation(summary = "주량 측정 결과 리스트 조회 API")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "주량 측정 결과 조회 성공", content = [Content(schema = Schema(implementation = DrinkingMeasurementListRes::class))]),
+            ApiResponse(responseCode = "404", description = "레포트가 존재하지 않음", content = [Content(schema = Schema(implementation = String::class))]),
+            ApiResponse(responseCode = "401", description = "토큰 정보 없거나 만료됨", content = [Content(schema = Schema(implementation = String::class))]),
+            ApiResponse(responseCode = "500", description = "서버 에러", content = [Content(schema = Schema(implementation = String::class))])
+        ]
+    )
+    @GetMapping("")
+    fun getReportList(@Parameter(hidden = true) user: User): ResponseEntity<DrinkingMeasurementListRes> {
+        val res = drinkingMeasurementApplicationService.getMeasurementReportList(user.kakaoUserId)
         return ResponseEntity.ok(res)
     }
 }

--- a/sulsul-api/src/main/kotlin/will/of/d/sulsul/alcohol/drinkingMeasurement/dto/response/DrinkingMeasurementListRes.kt
+++ b/sulsul-api/src/main/kotlin/will/of/d/sulsul/alcohol/drinkingMeasurement/dto/response/DrinkingMeasurementListRes.kt
@@ -1,0 +1,8 @@
+package will.of.d.sulsul.alcohol.drinkingMeasurement.dto.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+class DrinkingMeasurementListRes(
+    @Schema(description = "주량 측정 결과 리스트")
+    val cards: List<DrinkingMeasurementRes>
+)

--- a/sulsul-api/src/main/kotlin/will/of/d/sulsul/alcohol/drinkingMeasurement/dto/response/DrinkingMeasurementListRes.kt
+++ b/sulsul-api/src/main/kotlin/will/of/d/sulsul/alcohol/drinkingMeasurement/dto/response/DrinkingMeasurementListRes.kt
@@ -4,5 +4,5 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 class DrinkingMeasurementListRes(
     @Schema(description = "주량 측정 결과 리스트")
-    val cards: List<DrinkingMeasurementRes>
+    val cards: List<DrinkingMeasurementSummaryRes>
 )

--- a/sulsul-api/src/main/kotlin/will/of/d/sulsul/alcohol/drinkingMeasurement/dto/response/DrinkingMeasurementSummaryRes.kt
+++ b/sulsul-api/src/main/kotlin/will/of/d/sulsul/alcohol/drinkingMeasurement/dto/response/DrinkingMeasurementSummaryRes.kt
@@ -1,0 +1,40 @@
+package will.of.d.sulsul.alcohol.drinkingMeasurement.dto.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+import will.of.d.sulsul.alcohol.drinkingMeasurement.domain.DrinkingMeasurement
+import will.of.d.sulsul.alcohol.drinkingMeasurement.domain.Drinks
+import will.of.d.sulsul.common.findBy
+import will.of.d.sulsul.drink.domain.Drink
+import java.time.LocalDateTime
+
+class DrinkingMeasurementSummaryRes(
+    @Schema(description = "식별 id", example = "6481c97405e8335a58bc4337")
+    val id: String,
+    @Schema(description = "유저가 총 마신 알코올 양", example = "152.5")
+    val totalAlcoholAmount: Double,
+    @Schema(description = "유저가 총 마신 술의 잔", example = "4")
+    val totalDrinkGlasses: Int,
+    @Schema(description = "유저가 마신 날짜", example = "2021-08-20T15:00:00")
+    val drankAt: LocalDateTime,
+    @Schema(description = "유저가 마신 술의 종류와 잔 수", example = "[{\"drinkType\":\"소주\",\"glasses\":4}]")
+    val drinks: List<Drinks>
+) {
+    companion object {
+        fun of(drinkingMeasurement: DrinkingMeasurement): DrinkingMeasurementSummaryRes {
+            var totalAlcoholAmount: Double = 0.0
+
+            for (drinks in drinkingMeasurement.drinks) {
+                val drink: Drink? = Drink::type findBy drinks.drinkType
+                totalAlcoholAmount += drink!!.alcoholAmountPerGlass * drinks.glasses
+            }
+
+            return DrinkingMeasurementSummaryRes(
+                id = drinkingMeasurement.id.toString(),
+                totalAlcoholAmount = totalAlcoholAmount,
+                totalDrinkGlasses = drinkingMeasurement.totalDrinkGlasses,
+                drankAt = drinkingMeasurement.drankAt,
+                drinks = drinkingMeasurement.drinks
+            )
+        }
+    }
+}

--- a/sulsul-api/src/main/kotlin/will/of/d/sulsul/alcohol/drinkingMeasurement/service/DrinkingMeasurementApplicationService.kt
+++ b/sulsul-api/src/main/kotlin/will/of/d/sulsul/alcohol/drinkingMeasurement/service/DrinkingMeasurementApplicationService.kt
@@ -14,7 +14,7 @@ class DrinkingMeasurementApplicationService(
 ) {
     fun measurement(userId: Long, drinkingMeasurementReq: DrinkingMeasurementReq): DrinkingMeasurementRes {
         val (drinks, drinkingStartTime, drinkingEndTime, totalDrinkGlasses) = drinkingMeasurementReq
-        val drinkingMeasurementVO = DrinkingMeasurementVO.from(111L, drinks, drinkingStartTime, drinkingEndTime, totalDrinkGlasses)
+        val drinkingMeasurementVO = DrinkingMeasurementVO.from(userId, drinks, drinkingStartTime, drinkingEndTime, totalDrinkGlasses)
 
         val res = drinkingMeasurementService.measurement(drinkingMeasurementVO)
 

--- a/sulsul-api/src/main/kotlin/will/of/d/sulsul/alcohol/drinkingMeasurement/service/DrinkingMeasurementApplicationService.kt
+++ b/sulsul-api/src/main/kotlin/will/of/d/sulsul/alcohol/drinkingMeasurement/service/DrinkingMeasurementApplicationService.kt
@@ -1,7 +1,9 @@
 package will.of.d.sulsul.alcohol.drinkingMeasurement.service
 
 import org.springframework.stereotype.Service
+import will.of.d.sulsul.alcohol.drinkingMeasurement.domain.DrinkingMeasurement
 import will.of.d.sulsul.alcohol.drinkingMeasurement.dto.request.DrinkingMeasurementReq
+import will.of.d.sulsul.alcohol.drinkingMeasurement.dto.response.DrinkingMeasurementListRes
 import will.of.d.sulsul.alcohol.drinkingMeasurement.dto.response.DrinkingMeasurementRes
 import will.of.d.sulsul.alcohol.drinkingMeasurement.vo.DrinkingMeasurementVO
 import will.of.d.sulsul.exception.ReportNotFoundException
@@ -21,5 +23,12 @@ class DrinkingMeasurementApplicationService(
 
     fun getMeasurementReport(reportId: String): DrinkingMeasurementRes {
         return drinkingMeasurementService.findById(reportId)?.let { DrinkingMeasurementRes.of(it) } ?: throw ReportNotFoundException("Report not found with id: $reportId")
+    }
+
+    fun getMeasurementReportList(userId: Long): DrinkingMeasurementListRes {
+        val drinkingMeasurementList: List<DrinkingMeasurement> = drinkingMeasurementService.findAllByUserId(userId)
+        return DrinkingMeasurementListRes(
+            drinkingMeasurementList.map { DrinkingMeasurementRes.of(it) }
+        )
     }
 }

--- a/sulsul-api/src/main/kotlin/will/of/d/sulsul/alcohol/drinkingMeasurement/service/DrinkingMeasurementApplicationService.kt
+++ b/sulsul-api/src/main/kotlin/will/of/d/sulsul/alcohol/drinkingMeasurement/service/DrinkingMeasurementApplicationService.kt
@@ -5,6 +5,7 @@ import will.of.d.sulsul.alcohol.drinkingMeasurement.domain.DrinkingMeasurement
 import will.of.d.sulsul.alcohol.drinkingMeasurement.dto.request.DrinkingMeasurementReq
 import will.of.d.sulsul.alcohol.drinkingMeasurement.dto.response.DrinkingMeasurementListRes
 import will.of.d.sulsul.alcohol.drinkingMeasurement.dto.response.DrinkingMeasurementRes
+import will.of.d.sulsul.alcohol.drinkingMeasurement.dto.response.DrinkingMeasurementSummaryRes
 import will.of.d.sulsul.alcohol.drinkingMeasurement.vo.DrinkingMeasurementVO
 import will.of.d.sulsul.exception.ReportNotFoundException
 
@@ -28,7 +29,7 @@ class DrinkingMeasurementApplicationService(
     fun getMeasurementReportList(userId: Long): DrinkingMeasurementListRes {
         val drinkingMeasurementList: List<DrinkingMeasurement> = drinkingMeasurementService.findAllByUserId(userId)
         return DrinkingMeasurementListRes(
-            drinkingMeasurementList.map { DrinkingMeasurementRes.of(it) }
+            drinkingMeasurementList.map { DrinkingMeasurementSummaryRes.of(it) }
         )
     }
 }

--- a/sulsul-api/src/main/kotlin/will/of/d/sulsul/config/WebMvcConfig.kt
+++ b/sulsul-api/src/main/kotlin/will/of/d/sulsul/config/WebMvcConfig.kt
@@ -18,6 +18,7 @@ class WebMvcConfig(
             .excludePathPatterns("/health")
             .excludePathPatterns("/swagger-ui/**", "/v3/api-docs/**")
             .excludePathPatterns("/api/v1/drinkingLimit/share")
+            .excludePathPatterns("/api/v1/title")
     }
 
     override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver>) {

--- a/sulsul-domain/src/main/kotlin/will/of/d/sulsul/alcohol/drinkingMeasurement/repository/DrinkingMeasurementRepository.kt
+++ b/sulsul-domain/src/main/kotlin/will/of/d/sulsul/alcohol/drinkingMeasurement/repository/DrinkingMeasurementRepository.kt
@@ -4,4 +4,6 @@ import org.bson.types.ObjectId
 import org.springframework.data.mongodb.repository.MongoRepository
 import will.of.d.sulsul.alcohol.drinkingMeasurement.domain.DrinkingMeasurement
 
-interface DrinkingMeasurementRepository : MongoRepository<DrinkingMeasurement, ObjectId>
+interface DrinkingMeasurementRepository : MongoRepository<DrinkingMeasurement, ObjectId> {
+    fun findAllByUserId(userId: Long): List<DrinkingMeasurement>
+}

--- a/sulsul-domain/src/main/kotlin/will/of/d/sulsul/alcohol/drinkingMeasurement/service/DrinkingMeasurementService.kt
+++ b/sulsul-domain/src/main/kotlin/will/of/d/sulsul/alcohol/drinkingMeasurement/service/DrinkingMeasurementService.kt
@@ -34,23 +34,23 @@ class DrinkingMeasurementService(
 
         drinks.forEach() {
             when (it.drinkType) {
-                Drink.SOJU.name -> {
+                Drink.SOJU.drinkType -> {
                     averageAlcoholContent += Drink.SOJU.alcoholContent
                     totalCalorie += it.glasses * Drink.SOJU.calorie
                 }
-                Drink.BEER.name -> {
+                Drink.BEER.drinkType -> {
                     averageAlcoholContent += Drink.BEER.alcoholContent
                     totalCalorie += it.glasses * Drink.BEER.calorie
                 }
-                Drink.WINE.name -> {
+                Drink.WINE.drinkType -> {
                     averageAlcoholContent += Drink.WINE.alcoholContent
                     totalCalorie += it.glasses * Drink.WINE.calorie
                 }
-                Drink.WHISKY.name -> {
+                Drink.WHISKY.drinkType -> {
                     averageAlcoholContent += Drink.WHISKY.alcoholContent
                     totalCalorie += it.glasses * Drink.WHISKY.calorie
                 }
-                Drink.KAOLIANG.name -> {
+                Drink.KAOLIANG.drinkType -> {
                     averageAlcoholContent += Drink.KAOLIANG.alcoholContent
                     totalCalorie += it.glasses * Drink.KAOLIANG.calorie
                 }

--- a/sulsul-domain/src/main/kotlin/will/of/d/sulsul/alcohol/drinkingMeasurement/service/DrinkingMeasurementService.kt
+++ b/sulsul-domain/src/main/kotlin/will/of/d/sulsul/alcohol/drinkingMeasurement/service/DrinkingMeasurementService.kt
@@ -62,4 +62,8 @@ class DrinkingMeasurementService(
 
         return drinkingMeasurementRepository.save(document)
     }
+
+    fun findAllByUserId(userId: Long): List<DrinkingMeasurement> {
+        return drinkingMeasurementRepository.findAllByUserId(userId)
+    }
 }

--- a/sulsul-domain/src/test/kotlin/will/of/d/sulsul/alcohol/drinkingMeasurement/service/DrinkingMeasurementServiceTest.kt
+++ b/sulsul-domain/src/test/kotlin/will/of/d/sulsul/alcohol/drinkingMeasurement/service/DrinkingMeasurementServiceTest.kt
@@ -1,0 +1,53 @@
+package will.of.d.sulsul.alcohol.drinkingMeasurement.service
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import will.of.d.sulsul.SharedContext
+import will.of.d.sulsul.alcohol.drinkingMeasurement.domain.DrinkingMeasurement
+import will.of.d.sulsul.alcohol.drinkingMeasurement.domain.Drinks
+import will.of.d.sulsul.alcohol.drinkingMeasurement.repository.DrinkingMeasurementRepository
+import java.time.LocalDateTime
+
+class DrinkingMeasurementServiceTest(
+    private val drinkingMeasurementService: DrinkingMeasurementService,
+    private val drinkingMeasurementRepository: DrinkingMeasurementRepository
+) : SharedContext() {
+
+    @BeforeEach
+    fun createReport() {
+        val drinks: List<Drinks> = listOf(Drinks(drinkType = "소주", glasses = 5))
+
+        for (i in 1..5) {
+            drinkingMeasurementService.save(
+                DrinkingMeasurement(
+                    userId = 130L,
+                    drinkingDuration = "3시간 20분",
+                    alcoholCalorie = 100,
+                    averageAlcoholContent = 20.0,
+                    drinks = drinks,
+                    totalDrinkGlasses = 15,
+                    drankAt = LocalDateTime.now()
+                )
+            )
+        }
+    }
+
+    @AfterEach
+    fun deleteReport() {
+        drinkingMeasurementRepository.deleteAll()
+    }
+
+    @Test
+    fun getReportList() {
+        val drinkingMeasurementList: List<DrinkingMeasurement> = drinkingMeasurementService.findAllByUserId(130L)
+        Assertions.assertThat(drinkingMeasurementList.size).isEqualTo(5)
+    }
+
+    @Test
+    fun getEmptyReportList() {
+        val drinkingMeasurementList: List<DrinkingMeasurement> = drinkingMeasurementService.findAllByUserId(1L)
+        Assertions.assertThat(drinkingMeasurementList.size).isEqualTo(0)
+    }
+}


### PR DESCRIPTION
## 작업내용 
- 술약속 카드 리스트 조회 API
- 칭호(타이틀) 조회 API 는 인터셉터 로직 안타도록 수정